### PR TITLE
Fix typo

### DIFF
--- a/spring-style-guide.adoc
+++ b/spring-style-guide.adoc
@@ -437,7 +437,7 @@ NOTE: Code within sentences should be highlighted by using the code font. See
 
 
 [[spring-style-guide-words-avoid]]
-=== Words to Avoid or Avoid Misusuing
+=== Words to Avoid or Avoid Misusing
 
 "foo" and "bar":: "foo" and "bar" are often used in sample code. Doing so is a mistake for
 two reasons. First, more meaningful examples are more helpful. For example, a line of code

--- a/spring-style-guide.html
+++ b/spring-style-guide.html
@@ -761,7 +761,7 @@ words to more complex words and shorter words to longer words.</p>
 <p><a href="#spring-style-guide-highlighting">Highlighting</a></p>
 </li>
 <li>
-<p><a href="#spring-style-guide-words-avoid">Words to Avoid or Avoid Misusuing</a></p>
+<p><a href="#spring-style-guide-words-avoid">Words to Avoid or Avoid Misusing</a></p>
 </li>
 <li>
 <p><a href="#spring-style-guide-writing-numbers">Writing Numbers</a></p>
@@ -822,7 +822,7 @@ Code within sentences should be highlighted by using the code font. See
 </div>
 </div>
 <div class="sect2">
-<h3 id="spring-style-guide-words-avoid">Words to Avoid or Avoid Misusuing</h3>
+<h3 id="spring-style-guide-words-avoid">Words to Avoid or Avoid Misusing</h3>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">"foo" and "bar"</dt>


### PR DESCRIPTION
Hi,

I just learned that this style guide exists based on a [commit](https://github.com/spring-projects/spring-boot/issues/11224) that changes "foo" and "bar" to something less problematic.

Ironically, I think a typo has sneaked into the section headline of those words. Correct me if I'm wrong, but I think it should be **Misusing** instead of **Misusuing**.

Cheers,
Christoph